### PR TITLE
Re add imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
+markdown
 pyyaml
 regex

--- a/templatehelper.py
+++ b/templatehelper.py
@@ -15,7 +15,14 @@ import fnmatch
 import json
 import mimetypes
 import os
+# pylint: disable=unused-import
+import re
+# pylint: disable=unused-import
+import urllib
+from datetime import datetime, timezone, tzinfo
 
+# pylint: disable=unused-import
+import markdown
 import regex
 import yaml
 


### PR DESCRIPTION
During a recent code cleanup some supposedly unused imports were removed. These are used inside the jinja2 templates though and had to be re-added.

Comments were added to suppress unused-import warnings from pylint.