### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- insertion marker -->
+## [1.1.0](https://github.com/nomike/scms/releases/tag/1.1.0) - 2025-05-11
+
+<small>[Compare with 1.0.0](https://github.com/nomike/scms/compare/1.0.0...1.1.0)</small>
+
+This release adds support for org-files, which are a popular format for notes and task management.
+So instead of 'index' or 'index.md' files, you can now also use 'index.org'.
+
+This release adds `org-python` as a requirement. Be sure to run
+`pip install -r requirements.txt --upgrade` in your virtual environment to install the new
+dependency.
+
+Depending on your setup, you might also want to `killall scms.fcgi` to force the webserver to
+reload the application.
+
+### Added
+
+- Add support for org-files. ([fd9cc8b](https://github.com/nomike/scms/commit/fd9cc8bc55ec40677fea707ba6773eb2d5eaea07) by nomike).
+
 ## [1.0.0](https://github.com/nomike/scms/releases/tag/1.0.0) - 2025-05-11
 
 <small>[Compare with first commit](https://github.com/nomike/scms/compare/a880905b6acb03a98f817cde20d1dc552536e7e1...1.0.0)</small>

--- a/README.md
+++ b/README.md
@@ -145,3 +145,15 @@ This template is used to render error pages (e.g. HTTP/404).
 Optionally you could create templates for specific erro codes. The name has
 to be [errorcode].html (e.g. '404.html'). If no specific error template is
 found, sscm falls back to 'error.html'.
+
+## Development
+
+### Versioning
+
+This project uses [EffVer](https://jacobtomlinson.dev/effver/).
+
+Version numbers are comprised of three parts: Macro, Meso, Micro.
+
+If the macro version is incremented, expect a lare effort when upgrading.
+Meso version increments are usually small changes, but may require some effort.
+Micro version increments are usually bugfixes or small changes, which should not require any effort when upgrading.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flask
 markdown
+org-python
 pyyaml
 regex

--- a/templatehelper.py
+++ b/templatehelper.py
@@ -24,6 +24,8 @@ import locale
 
 # pylint: disable=unused-import
 import markdown
+# pylint: disable=unused-import
+import orgpython
 import regex
 import yaml
 
@@ -80,7 +82,7 @@ def listdir(path):
     If a file named "index" is present, it is supposed to be rendered as the main content of the
     page and thus it will be ommited from the list as well.
     """
-    ignorelist = ['index', 'index.md', '*.scmsfasicon', '*.scmstarget']
+    ignorelist = ['index', 'index.md', 'index.org', '*.scmsfasicon', '*.scmstarget']
     if os.path.exists(os.path.join(pathprefix, path, '.scmsignore')):
         with open(
                 os.path.join(pathprefix, path, '.scmsignore'),
@@ -113,7 +115,7 @@ def listchildren(path):
     If a file named "index" is present, it is supposed to be rendered as the main content of the
     page and thus it will be ommited from the list as well.
     """
-    ignorelist = ['index', 'index.md', '*.scmsfasicon', '*.scmstarget']
+    ignorelist = ['index', 'index.md', 'index.org', '*.scmsfasicon', '*.scmstarget']
     if os.path.exists(os.path.join(pathprefix, path, '.scmsignore')):
         with open(
                 os.path.join(pathprefix, path, '.scmsignore'),

--- a/templates/nomike.com/directory.html
+++ b/templates/nomike.com/directory.html
@@ -12,7 +12,8 @@
         <a href="{{ templatehelper.urllib.parse.quote(link) }}" target="{{ templatehelper.readfile(templatehelper.os.path.join(path, name + '.scmstarget')) }}"><i class="fas {{ templatehelper.getfasicon(templatehelper.os.path.join(path, name)) }}"></i> {{ name }}</a>        {% else %}
         <a href="{{ templatehelper.urllib.parse.quote(link) }}"><i class="fas {{ templatehelper.getfasicon(templatehelper.os.path.join(path, name)) }}"></i> {{ name }}</a> {% endif %} {% endfor %}
     </div>
-    {% endif -%} {% endblock -%} {% block content -%} {% if templatehelper.os.path.isfile(templatehelper.os.path.join(pathprefix, path,'index.md')) -%} {{ templatehelper.markdown.markdown(templatehelper.readfile(templatehelper.os.path.join(pathprefix,path,'index.md')),extensions=['fenced_code','toc','tables'])
-    | safe }} {% elif templatehelper.os.path.isfile(templatehelper.os.path.join(pathprefix, path, 'index')) -%} {{ templatehelper.readfile(templatehelper.os.path.join(pathprefix, path, 'index')) | safe -}} {% else -%}
+    {% endif -%} {% endblock -%} {% block content -%} {% if templatehelper.os.path.isfile(templatehelper.os.path.join(pathprefix, path,'index.org')) -%} {{ templatehelper.orgpython.to_html(templatehelper.readfile(templatehelper.os.path.join(pathprefix,path,'index.org')))
+    | safe }} {% elif templatehelper.os.path.isfile(templatehelper.os.path.join(pathprefix, path,'index.md')) -%} {{ templatehelper.markdown.markdown(templatehelper.readfile(templatehelper.os.path.join(pathprefix,path,'index.md')),extensions=['fenced_code','toc','tables'])
+    | safe }} {% else -%}
     <h1>/{{ path }}</h1>
     {% endif -%} {% if templatehelper.os.path.isdir(templatehelper.os.path.join(pathprefix, path, 'image')) %} {% include templatehelper.os.path.join(templatehelper.config['template'], 'gallery.html') %} {% endif %} {% endblock %}


### PR DESCRIPTION
## [1.1.0](https://github.com/nomike/scms/releases/tag/1.1.0) - 2025-05-11

<small>[Compare with 1.0.0](https://github.com/nomike/scms/compare/1.0.0...1.1.0)</small>

This release adds support for org-files, which are a popular format for notes and task management.
So instead of 'index' or 'index.md' files, you can now also use 'index.org'.

This release adds `org-python` as a requirement. Be sure to run
`pip install -r requirements.txt --upgrade` in your virtual environment to install the new
dependency.

Depending on your setup, you might also want to `killall scms.fcgi` to force the webserver to
reload the application.

### Added

- Add support for org-files. ([fd9cc8b](https://github.com/nomike/scms/commit/fd9cc8bc55ec40677fea707ba6773eb2d5eaea07) by nomike).